### PR TITLE
Init on new

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Splash with the new 0.10.1 (windows) logo.
 
 `new()` parameters:
 * `background`: `{r,g,b,a}` table used to clear the screen with. Set to `false` to draw underneath.
+
+Example: _Default the background to pink:_
+
+```lua
+slash = lib.new({background={255,0,255}})
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Make sure to hook the love callbacks up to `splash:update(dt)` and `splash:draw(
     local splash = require "o-ten-one"
     
     function love.load()
-      splash = o_ten_one.new()
+      splash = o_ten_one()
       splash.onDone = function() print "DONE" end
     end
     
@@ -36,7 +36,7 @@ Splash Interface
 The library only has one function you should use:
 
 ### `lib.new(...)`
-Instantiate a new `splash`.
+Instantiate a new `splash`. You can also do this by calling the library itself: `lib(...)`.
 Parameters depend on the specific splash (see below).
 
 The following members of the `splash` variable are of importance to you as a user:

--- a/main.lua
+++ b/main.lua
@@ -15,7 +15,7 @@ function love.load()
   for name, splash in pairs(splashes) do
     splash.module = require(splash.module)
     splashes[name] = function ()
-      return splash.module.new(unpack(splash))
+      return splash.module(unpack(splash))
     end
   end
 

--- a/o-ten-one/init.lua
+++ b/o-ten-one/init.lua
@@ -283,4 +283,6 @@ function splashlib:skip()
   end
 end
 
+setmetatable(splashlib, { __call = function(self) return self.new() end })
+
 return splashlib

--- a/o-ten-one/init.lua
+++ b/o-ten-one/init.lua
@@ -35,11 +35,12 @@ local colors = {
   shadow = {   0,   0,   0, 255 / 3 }
 }
 
-function splashlib.new(bg)
+function splashlib.new(init)
+  local init = init or {}
   local self = {}
   local width, height = love.graphics.getDimensions()
 
-  self.bg = bg == nil and colors.bg or bg
+  self.bg = init.bg or colors.bg
 
   -- radial mask shader
   self.shader = love.graphics.newShader[[


### PR DESCRIPTION
So instead of having arguments for the new operator like this:

``` lua
splash = splashlib.new(background,foreground,cactus)
```

leading to awkward situations when you only want cactus:

``` lua
splash = splashlib.new(nil,nil,cactus)
```

We can simply pass in a definition table that allows for the defaults to be overridden on creation:

``` lua
splash = splashlib.new{cactus=cactus}
```

The best thing about this is that it's easy to make forward compatible because the order doesn't matter. For example, let's say you add `cactus` after the you added `background`. The following call will work with both versions of the library, even if the `cactus` variable is not handled.

``` lua
splash = splashlib.new({background=background,cactus=cactus)
```

and now for a cat

![image](https://cloud.githubusercontent.com/assets/646162/13096511/89ac4214-d4df-11e5-9346-cc51f6c7106b.png)
