### PR TITLE
luacheck sanity changes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -7,17 +7,17 @@ local splashes = {
 
 local current, splash
 
-function next_splash()
+local function next_splash()
   current = next(splashes, current) or next(splashes)
   splash = splashes[current]()
   splash.onDone = next_splash
 end
 
 function love.load()
-  for name, splash in pairs(splashes) do
-    splash.module = require(splash.module)
+  for name, entry in pairs(splashes) do
+    entry.module = require(entry.module)
     splashes[name] = function ()
-      return splash.module(unpack(splash))
+      return entry.module(unpack(entry))
     end
   end
 


### PR DESCRIPTION
Since luacheck was complaining about them when I was looking over the code, I've gone ahead and removed some global variables and fixed local variables being shadowed :+1: (except for `timer.lua`, since I think that's library code?).

I've also changed `tween_and_wait(dur, pen, easing)` to actually use the `easing` argument, rather than how it was previously ignoring it and using a constant `"in-quad"`. This function is actually called with different easings (immediately below it) so this should be making a difference in the animations, but I'm not really noticing one. Make sure I'm not unintentionally messing it up by doing that. :smile:
